### PR TITLE
Fix Condition query under Python 3

### DIFF
--- a/sr/tools/inventory/query_ast.py
+++ b/sr/tools/inventory/query_ast.py
@@ -147,8 +147,7 @@ class Condition(Terminal):
             for name in expected:
                 count = 1
                 if isinstance(name, dict):
-                    count = name.values()[0]
-                    name = name.keys()[0]
+                    name, count = list(name.items())[0]
                 if name not in inv_node.types:
                     ret.append('broken')
                 if name in inv_node.types:


### PR DESCRIPTION
The `.keys()` and `.values()` methods on `dict` under Python 3 both return views rather than `list`s. As those views don't support indexing we wrap them in `list`s for compatibility with both Python 2 and 3.