### PR TITLE
Use info path over path so inv-set-attr works on ItemGroups

### DIFF
--- a/sr/tools/cli/inv_set_attr.py
+++ b/sr/tools/cli/inv_set_attr.py
@@ -35,7 +35,7 @@ def command(args):
     for code in args.asset:
         part = inv.root.parts[assetcode.normalise(code)]
         if part is not None:
-            replace_line(part.path, args.attrname, args.attrvalue)
+            replace_line(part.info_path, args.attrname, args.attrvalue)
         else:
             print("Could not find asset:", code, file=sys.stderr)
             sys.exit(1)


### PR DESCRIPTION
`ItemGroup`s are directories, so we need to open the `info` file within the directory. Happily `info_path` provides this already and is present (with suitable values) on both `ItemGroup`s and `Item` instances.