### PR TITLE
Drop Python 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
   - '2.7'
-  - '3.3'
   - '3.4'
   - '3.5'
   - '3.6'

--- a/setup.py
+++ b/setup.py
@@ -77,8 +77,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.2',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',


### PR DESCRIPTION
Even 3.4 is quite old at this point, however the killer here is that Python 3.3 doesn't seem to work on Travis. The error suggests something is going wrong during the install, but given the age of Python 3.3 I'm not sure it's worth fixing.