### PR TITLE
Include docs in source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,3 +4,4 @@ include sr/tools/cli/latex-assets.zip
 include sr/tools/cli/document_prefix.tex
 include sr/tools/cli/document_suffix.tex
 include sr/tools/cli/spend-template.yaml
+recursive-include docs *.rst conf.py config.example.yaml


### PR DESCRIPTION
Fixes #27.

I've tested installing from the resulting sdist tarball using the same procedure as in #27, and it succeeds without the `conf.py` error.