### PR TITLE
Update YAML and move to loading most inputs as untrusted

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     author='Student Robotics',
     author_email='info@studentrobotics.org',
     install_requires=[
-        'PyYAML >=3.11, <4',
+        'PyYAML >=3.11, !=4.*, <6',
         'sympy >=0.7, <1',
         'pyparsing >=2.0, <3',
         'BeautifulSoup4 >=4.3, <5',

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,8 @@ setup(
     author='Student Robotics',
     author_email='info@studentrobotics.org',
     install_requires=[
-        'PyYAML >=3.11, !=4.*, <6',
+        'PyYAML >=3.11, !=4.*, <6 ; python_version >= "3.5"',
+        'PyYAML >=3.11, <4 ; python_version <= "3.4"',
         'sympy >=0.7, <1',
         'pyparsing >=2.0, <3',
         'BeautifulSoup4 >=4.3, <5',

--- a/sr/tools/cli/budget_check.py
+++ b/sr/tools/cli/budget_check.py
@@ -31,7 +31,7 @@ def command(args):
             os.execv("./check", ["./check"] + sys.argv[1:])
         exit(1)
 
-    funds_in = yaml.load(f)
+    funds_in = yaml.safe_load(f)
     total_in = D(0)
 
     for i in funds_in["incoming"]:

--- a/sr/tools/cli/inv_new_group.py
+++ b/sr/tools/cli/inv_new_group.py
@@ -48,7 +48,7 @@ def command(args):
         open_editor(os.path.join(groupname, "info"))
 
     if args.create_all:
-        assy_data = yaml.load(open(templatefn))
+        assy_data = yaml.safe_load(open(templatefn))
         if "elements" in assy_data:
             os.chdir(groupname)
             for element in assy_data["elements"]:

--- a/sr/tools/cli/make_purchase.py
+++ b/sr/tools/cli/make_purchase.py
@@ -88,7 +88,7 @@ class SpendRequest(object):
         import yaml
 
         with open(self.fname, "r") as f:
-            data = yaml.load(f)
+            data = yaml.safe_load(f)
 
         self.username = data["username"]
         self.summary = data["summary"]

--- a/sr/tools/inventory/inventory.py
+++ b/sr/tools/inventory/inventory.py
@@ -141,7 +141,7 @@ def cached_yaml_load(path):
             except EOFError:
                 os.remove(p)  # cache file corrupted, recreate it
 
-    y = yaml.load(codecs.open(path, "r", encoding="utf-8"))
+    y = yaml.safe_load(codecs.open(path, "r", encoding="utf-8"))
     with open(p, 'wb') as file:
         pickle.dump(y, file)
     return y


### PR DESCRIPTION
This introduces use of `safe_load` almost everywhere that we load YAML data. The few places that we don't do so are more complex (and in areas of the code which are unused and pending removal).

We also declare support for PyYAML v5 (but not v4 as that version broke things), which has this safe API and now warns about use of plain `yaml.load`.