### PR TITLE
Don't need numpy in setup_requires any more

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,6 @@ setup(
         'docutils <0.16',  # https://github.com/sphinx-doc/sphinx/issues/6887; https://github.com/sphinx-doc/sphinx/pull/6918
         'Sphinx >=1.3, <2',  # Upgrading beyond 2.x? See if we can remove the docutils pin above.
         'Pygments >=2.0, <3',
-        'numpy >=1.9, <2'  # https://github.com/numpy/numpy/issues/2434#issuecomment-65252402
     ],
     extras_require={
         'cam-serial, usb-key-serial, sd-serial, mcv4b-part-code': ['pyudev'],


### PR DESCRIPTION
Not sure exactly what fix this, however it's not needed on a clean clone to install, when building dist or to run the tests (the latter no longer involve `setup.py`, which may be related).