### PR TITLE
Move build requirements to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[build-system]
+requires = [
+    "setuptools >= 40.9.0",
+    "Sphinx >=2, <7",
+    "Pygments >=2.0, <3",
+]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -52,10 +52,6 @@ setup(
         'tabulate >=0.7, <1',
         'xlwt-future >=0.8, <1',
     ],
-    setup_requires=[
-        'Sphinx >=2, <7',
-        'Pygments >=2.0, <3',
-    ],
     extras_require={
         'cam-serial, mcv4b-part-code': ['pyudev'],
         'price-graph': ['matplotlib'],


### PR DESCRIPTION
This enables building wheels using the latest setuptools and related tooling, while still distributing the man pages.