### PR TITLE
Move to flake8-bugbear

### DIFF
--- a/script/linting/requirements.txt
+++ b/script/linting/requirements.txt
@@ -1,11 +1,11 @@
 # Need 3.8 for fixes around typing comments
 flake8>=3.8
+flake8-bugbear
 flake8-builtins
 flake8-commas
 flake8-comprehensions
 flake8-debugger
 flake8-isort
-flake8-mutable
 flake8-todo
 flake8-tuple
 

--- a/sr/tools/bom/bom.py
+++ b/sr/tools/bom/bom.py
@@ -238,7 +238,7 @@ class MultiBoardBom(Bom):
 
         for num, board in self.boards:
             # Mmmmm. Horrible.
-            for i in range(num):
+            for _ in range(num):
                 for srcode, bpg in board.items():
                     if srcode not in self:
                         self[srcode] = PartGroup(bpg.part)

--- a/sr/tools/bom/bom.py
+++ b/sr/tools/bom/bom.py
@@ -22,12 +22,9 @@ class PartGroup(list):
     :param list designators: A list of designators
     """
 
-    def __init__(self, part, name="", designators=[]):
+    def __init__(self, part, name=""):
         """Create a new part group."""
         list.__init__(self)
-
-        for x in designators:
-            self.append((name, designators))
 
         self.part = part
         self.name = name

--- a/sr/tools/bom/geda.py
+++ b/sr/tools/bom/geda.py
@@ -11,7 +11,7 @@ def file_is_geda_pcb(f):
     f.seek(0)
 
     # 'PCB[' will occur at the start of one of the first 20 or so lines
-    for i in range(20):
+    for _ in range(20):
         if re.search(r"^\s*PCB[ \t]*\[", f.readline()) is not None:
             return True
     return False

--- a/sr/tools/bom/schem.py
+++ b/sr/tools/bom/schem.py
@@ -55,7 +55,7 @@ def open_schem(fname):
                     quantity = int(m.group(1))
                     code = m.group(2)
 
-                    for x in range(quantity):
+                    for _ in range(quantity):
                         newdes = "%s.%i" % (des, num)
 
                         new_items[newdes] = code

--- a/sr/tools/cli/create_bom.py
+++ b/sr/tools/cli/create_bom.py
@@ -254,7 +254,7 @@ def writeXLS(lines, out_fn):
     col_char_count = [0] * len(headings)
 
     bold_style = xlwt.easyxf("font: bold on;")
-    for colx, (heading, field) in enumerate(headings):
+    for colx, (heading, _field) in enumerate(headings):
         sheet.write(rowx, colx, heading, bold_style)
         col_char_count[colx] = max(col_char_count[colx], len(heading))
     rowx += 1
@@ -268,7 +268,7 @@ def writeXLS(lines, out_fn):
                 "pcodes": ", ".join(get_sorted_pcodes(line)),
             },
         )
-        for colx, (heading, field) in enumerate(headings):
+        for colx, (_heading, field) in enumerate(headings):
             sheet.write(rowx, colx, p[field])
             col_char_count[colx] = max(col_char_count[colx], len(str(p[field])))
         rowx += 1

--- a/sr/tools/cli/schedule_knockout.py
+++ b/sr/tools/cli/schedule_knockout.py
@@ -41,7 +41,7 @@ def command(args):
         ins_order.append(v)
 
     matches = []
-    for n in range(n_matches):
+    for _ in range(n_matches):
         matches += [[]]
 
     for n in range(args.n_teams):


### PR DESCRIPTION
[`flake8-mutable`](https://pypi.org/project/flake8-mutable/) is dead and broken (see e.g: https://github.com/ebeweber/flake8-mutable/issues/27). [Bugbear](https://pypi.org/project/flake8-bugbear/) offers a superset of lints. This PR moves to the latter and fixes issues found as a result, including a mutable parameter default.