### PR TITLE
Shift tested support forwards to current version of Python

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,11 +53,11 @@ references:
   python-full-version-matrix: &python-full-version-matrix
     matrix:
       parameters:
-        version: ["3.6", "3.7", "3.8", "3.9"]
+        version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
   python-top-and-bottom-version-matrix: &python-top-and-bottom-version-matrix
     matrix:
       parameters:
-        version: ["3.6", "3.9"]
+        version: ["3.7", "3.11"]
   filter-tags: &filter-tags
     filters:
       branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,7 @@ references:
       command: |
         python3 -m venv venv
         venv/bin/pip install -U pip setuptools wheel
+        venv/bin/pip install -U 'Sphinx <7'
         venv/bin/pip install -r all-requirements.txt
   save-dependencies-cache: &save-dependencies-cache
     save_cache:

--- a/setup.py
+++ b/setup.py
@@ -83,10 +83,11 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3 :: Only',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         'Topic :: Utilities',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,8 @@ setup(
         'xlwt-future >=0.8, <1',
     ],
     setup_requires=[
+        # Note: Sphinx needs to be manually installed before running `setup.py`
+        # to avoid issues importing `sphinxcontrib.applehelp`.
         'Sphinx >=2, <7',
         'Pygments >=2.0, <3',
     ],


### PR DESCRIPTION
Even supporting 3.7 here is likely a stretch as it goes out of support this summer.

Builds on https://github.com/srobo/tools/pull/55 to avoid other build system issues.