### PR TITLE
Tweaks to inv-mv to reduce pain points

### DIFF
--- a/sr/tools/cli/inv_mv.py
+++ b/sr/tools/cli/inv_mv.py
@@ -39,7 +39,7 @@ def command(args):
             print(f"Warning: Part {code} is already in {cwd}.")
             continue
 
-        if hasattr(part.parent, "code") and not args.ignore_assy:
+        if hasattr(part.parent, "code") and not args.no_warn_assy:
             if args.assy:
                 parts.append(part.parent)
             else:
@@ -73,7 +73,7 @@ def add_subparser(subparsers):
     )
     parser.add_argument(
         "-q",
-        "--ignore-assy",
+        "--no-warn-assy",
         action="store_true",
         help="Don't print warnings about items being part of an assembly.",
     )

--- a/sr/tools/cli/inv_mv.py
+++ b/sr/tools/cli/inv_mv.py
@@ -10,8 +10,14 @@ def command(args):
     cwd = os.getcwd()
 
     parts = []
+    seen_codes = set()
     for c in args.assetcodes:
         code = assetcode.normalise(c)
+
+        if code in seen_codes:
+            # This asset was already in an earlier argument
+            continue
+        seen_codes.add(code)
 
         try:
             assetcode.code_to_num(code)

--- a/sr/tools/cli/inv_mv.py
+++ b/sr/tools/cli/inv_mv.py
@@ -23,12 +23,16 @@ def command(args):
             assetcode.code_to_num(code)
         except ValueError:
             print(f"Error: {c} is an invalid asset code.", file=sys.stderr)
+            if args.ignore_invalid:
+                continue
             sys.exit(1)
 
         try:
             part = inv.root.parts[code]
         except KeyError:
             print(f"Error: There is no part with code {code}.", file=sys.stderr)
+            if args.ignore_invalid:
+                continue
             sys.exit(1)
 
         if part.parent.path == cwd:
@@ -72,6 +76,11 @@ def add_subparser(subparsers):
         "--ignore-assy",
         action="store_true",
         help="Don't print warnings about items being part of an assembly.",
+    )
+    parser.add_argument(
+        "--ignore-invalid",
+        action="store_true",
+        help="Continue with the move after encountering an invalid asset code.",
     )
 
     parser.add_argument(

--- a/sr/tools/cli/inv_mv.py
+++ b/sr/tools/cli/inv_mv.py
@@ -35,7 +35,7 @@ def command(args):
             print(f"Warning: Part {code} is already in {cwd}.")
             continue
 
-        if hasattr(part.parent, "code"):
+        if hasattr(part.parent, "code") and not args.ignore_assy:
             if args.assy:
                 parts.append(part.parent)
             else:
@@ -67,6 +67,13 @@ def add_subparser(subparsers):
         help="If the asset codes are part of an assembly then "
         "move the whole assembly.",
     )
+    parser.add_argument(
+        "-q",
+        "--ignore-assy",
+        action="store_true",
+        help="Don't print warnings about items being part of an assembly.",
+    )
+
     parser.add_argument(
         "assetcodes",
         metavar="ASSET_CODE",


### PR DESCRIPTION
Handful of changes to attempt to mitigate mistakes that occured at SR2025 kit collation.

- Deduplicates normalised asset codes passed in since git mv crashes if provided the same path multiple times
- Adds --ignore-assy option to suppress assembly warnings since this extra output meant errors were missed
- Adds --ignore-invalid to continue the command with any valid codes instead of aborting on the first invalid code